### PR TITLE
Picked up event should not change state (available, enrolled) of the responder

### DIFF
--- a/src/app/mission/mission.page.ts
+++ b/src/app/mission/mission.page.ts
@@ -96,9 +96,6 @@ export class MissionPage implements OnInit, OnDestroy {
   }
 
   async doPickedUp(): Promise<void> {
-    this.responder.available = true;
-    this.responder.enrolled = false;
-    await this.responderService.update(this.responder);
     await this.responderSimulatorService.updateStatus(this.mission, 'PICKEDUP');
   }
 


### PR DESCRIPTION
When a person responder picks up a victim (by clicking the 'picked up' button in the UI), an UpdateResponderCommand event is sent setting the status of the responder to available=true, enrolled=false. This is not very logical, as the fact of picking up an incident should only change the state of the incident, not the responder. For non-person responder, there is no update of the responder state when the responder picks up a victim.